### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/bekleyen-ores-vproje.py
+++ b/bekleyen-ores-vproje.py
@@ -85,7 +85,7 @@ while nextpage != 'DONE':
         for diff in reversed(diff_ids):
             damaging = requests.get('http://ores.wmflabs.org/scores/trwiki/damaging/' + str(diff)).json()[str(diff)]['probability']['true'] * 100
             reverted = requests.get('http://ores.wmflabs.org/scores/trwiki/reverted/' + str(diff)).json()[str(diff)]['probability']['true'] * 100
-            log = '[[Special:Diff/' + str(diff) + ' | ' + title + ']] - damaging= %.2f - reverted= %.2f' % (damaging, reverted)
+            log = '[[Special:Diff/' + str(diff) + ' | ' + title + ']] - damaging= {0:.2f} - reverted= {1:.2f}'.format(damaging, reverted)
             print log
             if damaging < threshold and reverted < threshold:
                 mavri.review_diff('tr.wikipedia', diff, xx)


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:Mavrikant:WikiBots?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:Mavrikant:WikiBots?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)